### PR TITLE
Add a couple packages to the initial setup script.

### DIFF
--- a/CODE/00_Startup.R
+++ b/CODE/00_Startup.R
@@ -1,10 +1,13 @@
 ## INSTALL THESE DEPENDENCIES
-install.packages("devtools",
-                 dependencies = TRUE,
-                 repos='http://cran.us.r-project.org')
-install.packages("Rcpp",
-                 dependencies = TRUE,
-                 repos='http://cran.us.r-project.org')
+install.packages(
+    c(
+        "devtools",
+        "Rcpp",
+        "data.table",
+        "glmnet",
+        "ggplot2"),
+    dependencies = TRUE,
+    repos='http://cran.us.r-project.org')
 
 ## Update two packages not on CRAN using the devtools package.
 devtools::install_github(repo = 'geneorama/geneorama')


### PR DESCRIPTION
Prior to this change, glmnet (and possibly other packages) wasn't installed until 30_glmnet_model.R actually got run, which is mildly annoying.

Tested by nuking my local R package directory and rerunning the pipeline from startup through 30_glmnet_model.R.

(Trivial pull request because this is the first time I've made one on Github, and because your contributions guide says I have to sign some kind of agreement.)