### PR TITLE
Create a script to read a candidate inspection pattern from CSV and evaluate its performance

### DIFF
--- a/CODE/29_init_with_data.R
+++ b/CODE/29_init_with_data.R
@@ -72,3 +72,7 @@ stopifnot(
     nrow(dat) == nrow(xmat),
     nrow(xmat) == nrow(mm))
 
+## Generate the "train" and "test" sets as distinct objects.
+trainSet <- dat[iiTrain]
+testSet <- dat[iiTest]
+stopifnot(nrow(trainSet) + nrow(testSet) == nrow(dat))

--- a/CODE/29_init_with_data.R
+++ b/CODE/29_init_with_data.R
@@ -1,0 +1,74 @@
+
+##==============================================================================
+## INITIALIZE
+##==============================================================================
+if(interactive()){
+    ## Remove all objects; perform garbage collection
+    rm(list=ls())
+    gc(reset=TRUE)
+    ## Detach libraries that are not used
+    geneorama::detach_nonstandard_packages()
+}
+## Load libraries that are used
+geneorama::loadinstall_libraries(c("data.table", "glmnet", "ggplot2"))
+## Load custom functions
+geneorama::sourceDir("CODE/functions/")
+
+##==============================================================================
+## LOAD CACHED RDS FILES
+##==============================================================================
+dat <- readRDS("DATA/dat_model.Rds")
+
+## Only keep "Retail Food Establishment"
+dat <- dat[LICENSE_DESCRIPTION == "Retail Food Establishment"]
+## Remove License Description
+dat[ , LICENSE_DESCRIPTION := NULL]
+dat <- na.omit(dat)
+
+## Add criticalFound variable to dat:
+dat[ , criticalFound := pmin(1, criticalCount)]
+
+## Set the key for dat
+setkey(dat, Inspection_ID)
+
+## Match time period of original results
+# dat <- dat[Inspection_Date < "2013-09-01" | Inspection_Date > "2014-07-01"]
+
+##==============================================================================
+## CREATE MODEL DATA
+##==============================================================================
+# sort(colnames(dat))
+xmat <- dat[ , list(Inspector = Inspector_Assigned,
+                    pastSerious = pmin(pastSerious, 1),
+                    pastCritical = pmin(pastCritical, 1),
+                    timeSinceLast,
+                    ageAtInspection = ifelse(ageAtInspection > 4, 1L, 0L),
+                    consumption_on_premises_incidental_activity,
+                    tobacco_retail_over_counter,
+                    temperatureMax,
+                    heat_burglary = pmin(heat_burglary, 70),
+                    heat_sanitation = pmin(heat_sanitation, 70),
+                    heat_garbage = pmin(heat_garbage, 50),
+                    # Facility_Type,
+                    criticalFound),
+            keyby = Inspection_ID]
+mm <- model.matrix(criticalFound ~ . -1, data=xmat[ , -1, with=F])
+mm <- as.data.table(mm)
+str(mm)
+colnames(mm)
+
+##==============================================================================
+## CREATE TEST / TRAIN PARTITIONS
+##==============================================================================
+## 2014-07-01 is an easy separator
+dat[Inspection_Date < "2014-07-01", range(Inspection_Date)]
+dat[Inspection_Date > "2014-07-01", range(Inspection_Date)]
+
+iiTrain <- dat[ , which(Inspection_Date < "2014-07-01")]
+iiTest <- dat[ , which(Inspection_Date > "2014-07-01")]
+
+## Check to see if any rows didn't make it through the model.matrix formula
+stopifnot(
+    nrow(dat) == nrow(xmat),
+    nrow(xmat) == nrow(mm))
+

--- a/CODE/30_glmnet_model.R
+++ b/CODE/30_glmnet_model.R
@@ -68,9 +68,9 @@ iiTrain <- dat[ , which(Inspection_Date < "2014-07-01")]
 iiTest <- dat[ , which(Inspection_Date > "2014-07-01")]
 
 ## Check to see if any rows didn't make it through the model.matrix formula
-nrow(dat)
-nrow(xmat)
-nrow(mm)
+stopifnot(
+    nrow(dat) == nrow(xmat),
+    nrow(xmat) == nrow(mm))
 
 ##==============================================================================
 ## GLMNET MODEL

--- a/CODE/30_glmnet_model.R
+++ b/CODE/30_glmnet_model.R
@@ -1,76 +1,14 @@
-
 ##==============================================================================
 ## INITIALIZE
 ##==============================================================================
-if(interactive()){
-    ## Remove all objects; perform garbage collection
-    rm(list=ls())
-    gc(reset=TRUE)
-    ## Detach libraries that are not used
-    geneorama::detach_nonstandard_packages()
-}
-## Load libraries that are used
-geneorama::loadinstall_libraries(c("data.table", "glmnet", "ggplot2"))
-## Load custom functions
-geneorama::sourceDir("CODE/functions/")
 
-##==============================================================================
-## LOAD CACHED RDS FILES
-##==============================================================================
-dat <- readRDS("DATA/dat_model.Rds")
-
-## Only keep "Retail Food Establishment"
-dat <- dat[LICENSE_DESCRIPTION == "Retail Food Establishment"]
-## Remove License Description
-dat[ , LICENSE_DESCRIPTION := NULL]
-dat <- na.omit(dat)
-
-## Add criticalFound variable to dat:
-dat[ , criticalFound := pmin(1, criticalCount)]
-
-## Set the key for dat
-setkey(dat, Inspection_ID)
-
-## Match time period of original results
-# dat <- dat[Inspection_Date < "2013-09-01" | Inspection_Date > "2014-07-01"]
-
-##==============================================================================
-## CREATE MODEL DATA
-##==============================================================================
-# sort(colnames(dat))
-xmat <- dat[ , list(Inspector = Inspector_Assigned,
-                    pastSerious = pmin(pastSerious, 1),
-                    pastCritical = pmin(pastCritical, 1),
-                    timeSinceLast,
-                    ageAtInspection = ifelse(ageAtInspection > 4, 1L, 0L),
-                    consumption_on_premises_incidental_activity,
-                    tobacco_retail_over_counter,
-                    temperatureMax,
-                    heat_burglary = pmin(heat_burglary, 70),
-                    heat_sanitation = pmin(heat_sanitation, 70),
-                    heat_garbage = pmin(heat_garbage, 50),
-                    # Facility_Type,
-                    criticalFound),
-            keyby = Inspection_ID]
-mm <- model.matrix(criticalFound ~ . -1, data=xmat[ , -1, with=F])
-mm <- as.data.table(mm)
-str(mm)
-colnames(mm)
-
-##==============================================================================
-## CREATE TEST / TRAIN PARTITIONS
-##==============================================================================
-## 2014-07-01 is an easy separator
-dat[Inspection_Date < "2014-07-01", range(Inspection_Date)]
-dat[Inspection_Date > "2014-07-01", range(Inspection_Date)]
-
-iiTrain <- dat[ , which(Inspection_Date < "2014-07-01")]
-iiTest <- dat[ , which(Inspection_Date > "2014-07-01")]
-
-## Check to see if any rows didn't make it through the model.matrix formula
-stopifnot(
-    nrow(dat) == nrow(xmat),
-    nrow(xmat) == nrow(mm))
+# Initialize by directly generating the data matrices from earlier
+# stages.
+#
+# TODO: Refactor to read in CSVs or something instead? That might not
+# be such a great idea if the form of the data changes radically in
+# future, though.
+source("CODE/29_init_with_data.R", echo = FALSE)
 
 ##==============================================================================
 ## GLMNET MODEL

--- a/CODE/30_glmnet_model.R
+++ b/CODE/30_glmnet_model.R
@@ -62,6 +62,13 @@ dat$glm_pred <- predict(model, newx=as.matrix(mm),
                         s=lam, 
                         type="response")[,1]
 
+# Generate the expected output format for evaluation.
+#
+# TODO: This is a bit of a mess, but it'll do for now.
+dat$inspection.priority <- dat$glm_pred
+write.csv(dat, file="glm_pred.csv", row.names=FALSE)
+
+
 # Show gini performance of inspector model on tune data set
 dat[iiTest, gini(glm_pred, criticalFound, plot=TRUE)]
 

--- a/CODE/30_glmnet_model.R
+++ b/CODE/30_glmnet_model.R
@@ -66,7 +66,7 @@ dat$glm_pred <- predict(model, newx=as.matrix(mm),
 #
 # TODO: This is a bit of a mess, but it'll do for now.
 dat$inspection.priority <- dat$glm_pred
-write.csv(dat, file="glm_pred.csv", row.names=FALSE)
+write.csv(dat[iiTest], file="glm_pred.csv", row.names=FALSE)
 
 
 # Show gini performance of inspector model on tune data set

--- a/CODE/40_evaluate_schedule.R
+++ b/CODE/40_evaluate_schedule.R
@@ -1,0 +1,95 @@
+## USAGE: Rscript 40_evaluate_schedule.R proposed_schedule.csv
+##
+## Evaluates the performance of a proposed prioritization of
+## inspection targets, as given by a CSV file.
+##
+## The proposed_schedule.csv file is expected to have a header line,
+## and then as many rows as there are in the test set from
+## init_with_data. Each row 'i' in proposed_schedule.csv is assumed to
+## correspond to the i'th test set element. The inspection priority is
+## expected to be in a column named "inspection.priority".
+##
+## Performance is evaluated by simulating performing the inspections
+## in descending order of inspection.priority and checking in several
+## different ways how much faster violations would have been found if
+## this order had been used.
+
+##==============================================================================
+## INITIALIZE
+##==============================================================================
+
+# Initialize by directly generating the data matrices from earlier
+# stages, including the "train" and "test" sets as used in the
+# original evaluation.
+source("CODE/29_init_with_data.R", echo = FALSE)
+
+# Load in the prioritization file.
+args <- commandArgs(trailingOnly=TRUE)
+# TODO: Print usage message instead of crashing outright.
+stopifnot(length(args) == 1)
+sched <- read.csv(args[1])
+
+# Ignore everything about the loaded schedule except the
+# inspection.priority column. Paste that column onto the test set.
+nrow(sched)
+nrow(testSet)
+stopifnot(nrow(sched) == nrow(testSet))
+testSet$inspection.priority <- sched$inspection.priority
+
+
+##==============================================================================
+## ANALYZE
+##==============================================================================
+
+
+# Show gini performance of inspector model on tune data set
+dat[iiTest, gini(glm_pred, criticalFound, plot=TRUE)]
+
+## Calculate confusion matrix values for evaluation
+calculate_confusion_values(actual = xmat[iiTest, criticalFound],
+                           expected = dat[iiTest, glm_pred], 
+                           r = .25)
+
+## Calculate matrix of confusion matrix values for evaluation
+confusion_values_test <- t(sapply(seq(0, 1 ,.01), 
+                                  calculate_confusion_values,
+                                  actual = xmat[iiTest, criticalFound],
+                                  expected = dat[iiTest, glm_pred]))
+confusion_values_test
+ggplot(reshape2::melt(as.data.table(confusion_values_test), 
+                      id.vars="r")) + 
+    aes(x=r, y=value, colour=variable) + geom_line() + 
+    geom_hline(yintercept = c(0,1))
+
+##==============================================================================
+## CALCULATION OF LIFT
+##==============================================================================
+## TEST PERIOD: Date range
+dat[iiTest, range(Inspection_Date)]
+## TEST PERIOD: Total inspections
+dat[iiTest, .N]
+## TEST PERIOD: Critical found
+dat[iiTest, sum(criticalCount)]
+## TEST PERIOD: Inspections with any critical violations
+dat[iiTest, sum(criticalFound)]
+
+## Subset test period
+datTest <- dat[iiTest]
+## Identify first period
+datTest[ , period := ifelse(Inspection_Date < median(Inspection_Date),1,2)]
+datTest[, .N, keyby=list(period)]
+datTest[, .N, keyby=list(Inspection_Date, period)]
+## Identify top half of scores (which would have been the first period)
+datTest[ , period_modeled := ifelse(glm_pred > median(glm_pred), 1, 2)]
+
+datTest[period == 1, sum(criticalFound)]
+datTest[period_modeled == 1, sum(criticalFound)]
+
+datTest[, list(.N, Violations = sum(criticalFound)), keyby=list(period)]
+datTest[, list(.N, Violations = sum(criticalFound)), keyby=list(period_modeled)]
+
+141 / (141 + 117)
+178 / (178 + 80)
+0.6899225 - .5465116
+
+

--- a/CODE/40_evaluate_schedule.R
+++ b/CODE/40_evaluate_schedule.R
@@ -41,53 +41,29 @@ testSet$inspection.priority <- sched$inspection.priority
 
 
 # Show gini performance of inspector model on tune data set
-dat[iiTest, gini(glm_pred, criticalFound, plot=TRUE)]
-
-## Calculate confusion matrix values for evaluation
-calculate_confusion_values(actual = xmat[iiTest, criticalFound],
-                           expected = dat[iiTest, glm_pred], 
-                           r = .25)
-
-## Calculate matrix of confusion matrix values for evaluation
-confusion_values_test <- t(sapply(seq(0, 1 ,.01), 
-                                  calculate_confusion_values,
-                                  actual = xmat[iiTest, criticalFound],
-                                  expected = dat[iiTest, glm_pred]))
-confusion_values_test
-ggplot(reshape2::melt(as.data.table(confusion_values_test), 
-                      id.vars="r")) + 
-    aes(x=r, y=value, colour=variable) + geom_line() + 
-    geom_hline(yintercept = c(0,1))
+testSet[gini(inspection.priority, criticalFound, plot=TRUE)]
 
 ##==============================================================================
 ## CALCULATION OF LIFT
 ##==============================================================================
 ## TEST PERIOD: Date range
-dat[iiTest, range(Inspection_Date)]
+testSet[, range(Inspection_Date)]
 ## TEST PERIOD: Total inspections
-dat[iiTest, .N]
+testSet[, .N]
 ## TEST PERIOD: Critical found
-dat[iiTest, sum(criticalCount)]
+testSet[, sum(criticalCount)]
 ## TEST PERIOD: Inspections with any critical violations
-dat[iiTest, sum(criticalFound)]
+testSet[, sum(criticalFound)]
 
-## Subset test period
-datTest <- dat[iiTest]
 ## Identify first period
-datTest[ , period := ifelse(Inspection_Date < median(Inspection_Date),1,2)]
-datTest[, .N, keyby=list(period)]
-datTest[, .N, keyby=list(Inspection_Date, period)]
+testSet[, period := ifelse(Inspection_Date < median(Inspection_Date),1,2)]
+testSet[, .N, keyby=list(period)]
+testSet[, .N, keyby=list(Inspection_Date, period)]
 ## Identify top half of scores (which would have been the first period)
-datTest[ , period_modeled := ifelse(glm_pred > median(glm_pred), 1, 2)]
+testSet[, period_modeled := ifelse(inspection.priority > median(inspection.priority), 1, 2)]
 
-datTest[period == 1, sum(criticalFound)]
-datTest[period_modeled == 1, sum(criticalFound)]
+testSet[period == 1, sum(criticalFound)]
+testSet[period_modeled == 1, sum(criticalFound)]
 
-datTest[, list(.N, Violations = sum(criticalFound)), keyby=list(period)]
-datTest[, list(.N, Violations = sum(criticalFound)), keyby=list(period_modeled)]
-
-141 / (141 + 117)
-178 / (178 + 80)
-0.6899225 - .5465116
-
-
+testSet[, list(.N, Violations = sum(criticalFound)), keyby=list(period)]
+testSet[, list(.N, Violations = sum(criticalFound)), keyby=list(period_modeled)]

--- a/CODE/40_evaluate_schedule.R
+++ b/CODE/40_evaluate_schedule.R
@@ -31,8 +31,6 @@ sched <- read.csv(args[1])
 
 # Ignore everything about the loaded schedule except the
 # inspection.priority column. Paste that column onto the test set.
-nrow(sched)
-nrow(testSet)
 stopifnot(nrow(sched) == nrow(testSet))
 testSet$inspection.priority <- sched$inspection.priority
 

--- a/CODE/40_evaluate_schedule.R
+++ b/CODE/40_evaluate_schedule.R
@@ -65,5 +65,17 @@ testSet[, period_modeled := ifelse(inspection.priority > median(inspection.prior
 testSet[period == 1, sum(criticalFound)]
 testSet[period_modeled == 1, sum(criticalFound)]
 
-testSet[, list(.N, Violations = sum(criticalFound)), keyby=list(period)]
-testSet[, list(.N, Violations = sum(criticalFound)), keyby=list(period_modeled)]
+BAU_period_violations <- testSet[, list(.N, Violations = sum(criticalFound)), keyby=list(period)]
+BAU_period_violations
+Model_period_violations <- testSet[, list(.N, Violations = sum(criticalFound)), keyby=list(period_modeled)]
+Model_period_violations
+
+print("Percent of critical violations found in period 1 (business as usual):")
+print(BAU_period_violations$Violations[1]
+      /
+      sum(BAU_period_violations$Violations))
+
+print("Percent of critical violations found in period 1 (model):")
+print(Model_period_violations$Violations[1]
+      /
+      sum(Model_period_violations$Violations))

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ REQUIREMENTS
 
 All of the code in this project uses the open source statistical application, R.  We advise that you use ```R version >= 3.1``` for best results. 
 
+Ubunutu users may need to install `libssl-dev`, `libcurl4-gnutls-dev`, and `libxml2-dev`.  This can be accomplished by typing the following command at the command line:
+`sudo apt-get install libssl-dev libcurl4-gnutls-dev libxml2-dev`
+
 The code makes extensive usage of the ``data.table`` package. If you are not familiar with the package, you might want to consult the data.table [FAQ available on CRAN] (http://cran.r-project.org/web/packages/data.table/vignettes/datatable-faq.pdf).
 
 


### PR DESCRIPTION
This batch of changes is oriented around the creation of a new script, 40_evaluate_schedule.R, which evaluates a proposed inspection pattern's performance versus the "business as usual" benchmark. It accepts the proposed inspection pattern as a CSV input; read the notes at the top of the new script for more details.

Currently, the only evaluation actually performed is the "Percentage of period 1 & 2 critical violations found in Period 1" comparison found in the white paper; I plan to port the other evaluations later, once this pull request has been accepted and therefore approved the general architectural approach.

This pull request also introduces a new script, 29_init_with_data.R, whose purpose is to be source()'d by scripts to load the dataset into a useful collection of variables. 40_evaluate_schedule.R uses this new script to load the "train" and "test" sets in order to run its comparison. The intent is that this new script will also be used to dump the "train" and "test" sets to CSV files to make prototyping future models easier, but this is not yet implemented.

30_glmnet_model.R has been modified to (1) load data by source()ing 29_init_with_data.R, and (2) to generate an output CSV file readable by 40_evaluate_schedule.R.

(Note: this pull request includes the changes from pull request #72; the expectation is that you will merge #72 before accepting this one.)
