### PR TITLE
Fix typo on GitHub Pages site

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
                     <li>Nearby garbage and sanitation complaints</li>
                     <li>The type of facility being inspected</li>
                     <li>Nearby burglaries</li>
-                    <li>Whether the establishment has a tobacco license or has an indicental alcohol consumption license</li>
+                    <li>Whether the establishment has a tobacco license or has an incidental alcohol consumption license</li>
                     <li>Length of time since last inspection</li>
                     <li>The length of time the establishment has been operating</li>
                 </ul>


### PR DESCRIPTION
The GitHub Pages splash page (which is awesome) currently includes, as one of the potential data points:

> Whether the establishment has a tobacco license or has an **indicental** alcohol consumption license

Per [the Business Affairs and Consumer Protection website](http://www.cityofchicago.org/city/en/depts/bacp/supp_info/classes_of_liquorlicenses.html), I believe this should be an "incidental" alcohol consumption license:

> ### Consumption on Premises-Incidental Activity License
> 
> Restaurants, hotels, banquet halls, theaters and bowling alleys that would like to sell liquor are required to have a Consumption on Premises-Incidental Activity (COP) license. In other words, this license is required for the retail sale of alcohol to be consumed on the premises at a place of business where the sale of alcoholic liquor is incidental or secondary to the primary activity. Moratorium restrictions do not apply for restaurants seeking a COP license. However, moratorium restrictions may apply to other businesses seeking a COP license. Businesses with a COP typically require additional licenses depending on the business activity.

Nice work! :beer: :smile:
