### PR TITLE
Removed non-existent dependency and updated docs

### DIFF
--- a/CODE/00_Startup.R
+++ b/CODE/00_Startup.R
@@ -10,6 +10,5 @@ install.packages("Rcpp",
 devtools::install_github(repo = 'geneorama/geneorama')
 devtools::install_github(repo = 'yihui/printr')
 
-## Update RSocrata to a particular build not yet released:
-devtools::install_github(repo = 'chicago/RSocrata', ref = "sprint7")
+## removed RSocrata install because the data is available in the repository
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ SCRIPT ORGANIZATION
 
 The scripts are contained in `./CODE`. 
 
-The most important scripts are `00_Startup.R` which installs R dependencies and  `30_glmnet_model.R`, which contains our current risk model. 
+Our results can be reproduced by running `00_Startup.R` which installs R dependencies and `30_glmnet_model.R`, which contains our current risk model. The data have already been downloaded and prepared. The data files are in the `./DATA` directory. The data preparation scripts are a useful reference for those seeking to extract additional features from the raw data.  
 
-The other scripts download and prepare the data. These data are already in the `./DATA` directory, so you should not need to run thes scripts.
 
 DATA
 ------


### PR DESCRIPTION
The RSocrata branch referenced in the install script no longer exists. You get the error:
```
Downloading GitHub repo chicago/RSocrata@sprint7
from URL https://api.github.com/repos/chicago/RSocrata/zipball/sprint7
Error in download(dest, src, auth) : client error: (404) Not Found
```

In addition, it looks like the updates to read.socrata that the download scripts depend on were never integrated into master.

Because the data already exists, I removed the install of RSocrata and updated the main readme to make it explicit that all that needs to be done to reproduce the results is run the install and glmnet scripts.

You might also consider moving the download scripts into an archive directory under CODE since they no longer work.

Note: vim added a new line character at the end of the file which is why the Acknowledgements changed.